### PR TITLE
delete fix

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -216,7 +216,7 @@ const RestAPI = (API) => class extends API {
                 },
                 create: (body, cb) => this._request('POST', path, body, cb),
                 update: (id, body, cb) => this._request('PATCH', `${path}/${id}`, body, cb),
-                delete: (id, cb) => this._request('DELETE', `${path}/${id}?force: true`, null, cb)
+                delete: (id, cb) => this._request('DELETE', `${path}/${id}`, null, cb)
             };
             if (path === 'messages') {
                 this[path].replace = (id, body, cb) => this._request('PUT', `${path}/${id}`, body, cb);
@@ -309,7 +309,7 @@ const RestAPI = (API) => class extends API {
             url: `v2/${path}${querystring}`
         };
         debug('using options:', JSON.stringify(options));
-        if (['POST', 'PATCH', 'DELETE'].includes(method)) {
+        if (['POST', 'PATCH'].includes(method)) {
             options.json = json;
         }
         if (pagination && method === 'GET') {


### PR DESCRIPTION
The http DELETE request method does not accept/need a payload. This fixes: `api.RESOURCE.delete('....');`